### PR TITLE
tick pyduke-energy version to 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -
 
+## [0.0.11] - 2021-12-15
+
+### Fixed
+
+- Tick `pyduke-energy` version to 0.0.15 to fix an issue where the usage measurement was extremely high (fixes #50)
+
 ## [0.0.10] - 2021-09-21
 
 ### Fixed
@@ -83,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pulls today's current energy usage into entity sensor.duke_energy_usage_today_kwh
 
-[unreleased]: https://github.com//mjmeli/ha-duke-energy-gateway/compare/0.0.10...HEAD
+[unreleased]: https://github.com//mjmeli/ha-duke-energy-gateway/compare/0.0.11...HEAD
+[0.0.11]: https://github.com/mjmeli/ha-duke-energy-gateway/releases/tag/0.0.11
 [0.0.10]: https://github.com/mjmeli/ha-duke-energy-gateway/releases/tag/0.0.10
 [0.0.9]: https://github.com/mjmeli/ha-duke-energy-gateway/releases/tag/0.0.9
 [0.0.8]: https://github.com/mjmeli/ha-duke-energy-gateway/releases/tag/0.0.8

--- a/custom_components/duke_energy_gateway/manifest.json
+++ b/custom_components/duke_energy_gateway/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "duke_energy_gateway",
   "name": "Duke Energy Gateway",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "documentation": "https://github.com/mjmeli/ha-duke-energy-gateway",
   "issue_tracker": "https://github.com/mjmeli/ha-duke-energy-gateway/issues",
   "dependencies": [],
   "config_flow": true,
   "codeowners": ["@mjmeli"],
-  "requirements": ["pyduke-energy==0.0.5"],
+  "requirements": ["pyduke-energy==0.0.15"],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Tick `pyduke-energy` version to 0.0.15 to fix an issue where the usage measurement was extremely high (fixes #50)