### PR TITLE
tick pyduke-energy version to v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -
 
+## [0.1.3] - 2023-01-06
+
+### Fixed
+
+- Update pydukeenergy version to 1.0.3 to fix realtime stream constantly timing out (fixes #153)
+
 ## [0.1.2] - 2022-09-07
 
 ### Fixed

--- a/custom_components/duke_energy_gateway/manifest.json
+++ b/custom_components/duke_energy_gateway/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "duke_energy_gateway",
   "name": "Duke Energy Gateway",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "documentation": "https://github.com/mjmeli/ha-duke-energy-gateway",
   "issue_tracker": "https://github.com/mjmeli/ha-duke-energy-gateway/issues",
   "dependencies": [],
   "config_flow": true,
   "codeowners": ["@mjmeli"],
-  "requirements": ["pyduke-energy==1.0.2"],
+  "requirements": ["pyduke-energy==1.0.3"],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Update pydukeenergy version to 1.0.3 to fix realtime stream constantly timing out (fixes #153)